### PR TITLE
Build and push CI image to GHCR

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,9 @@ on:
   pull_request:
     branches: [ main ]
 
+permissions:
+  packages: write
+
 jobs:
   build:
     runs-on: ${{ matrix.os }}
@@ -15,13 +18,24 @@ jobs:
     steps:
       - uses: actions/checkout@v5
 
-      - name: Set up vcpkg
-        uses: lukka/run-vcpkg@v11
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
         with:
-          vcpkgGitCommitId: 'dd3097e305afa53f7b4312371f62058d2e665320'
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Install libgsf (for tests only)
-        run: sudo apt-get -y install libgsf-bin
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          push: true
+          tags: |
+            ghcr.io/${{ github.repository_owner }}/containerfs-ci:latest
+            ghcr.io/${{ github.repository_owner }}/containerfs-ci:${{ github.sha }}
 
-      - name: Run release workflow
-        run: cmake --workflow --preset release
+      - name: Pull published image
+        run: docker pull ghcr.io/${{ github.repository_owner }}/containerfs-ci:latest
+
+      - name: Run tests in container
+        run: docker run --rm ghcr.io/${{ github.repository_owner }}/containerfs-ci:latest


### PR DESCRIPTION
## Summary
- push Docker image to GitHub Container Registry during CI
- run tests from the published container image

## Testing
- `yamllint .github/workflows/ci.yml` *(fails: command not found)*
- `pip install yamllint` *(fails: Could not connect to proxy, 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68b576a188a8833088b6393b3c7ff07d